### PR TITLE
fix: removed add() call in tournee functions

### DIFF
--- a/src/main/java/com/mycompany/cvrp/solution/Tournee.java
+++ b/src/main/java/com/mycompany/cvrp/solution/Tournee.java
@@ -306,7 +306,6 @@ public class Tournee {
                 if(op.isMeilleur(best) && !ListeTabou.getInstance().isTabou(op)) {
                     best = op;
                 } 
-                ListeTabou.getInstance().add(op);
             }
         }    
         return best;
@@ -322,7 +321,6 @@ public class Tournee {
                 if(op.isMeilleur(best) && !ListeTabou.getInstance().isTabou(op)) {
                     best = op;
                 }
-                ListeTabou.getInstance().add(op);
             }
         }    
         return best;


### PR DESCRIPTION
add() is called in RechercheTabou, it shouldn't be called directly in the functions inside tournee or else the tabou list is going to be used in RechercheLocale as well.